### PR TITLE
SYS-2181: custom dns entry for AIPS

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+aips.aventus.io


### PR DESCRIPTION
**WHAT**
- adds a custom dns for the AIPs doc - [aips.aventus.io](aips.aventus.io)

**WHY**
- requirement from https://aventus-network-services.atlassian.net/browse/SYS-2181
